### PR TITLE
Update to eclipse-temurin:21 and remove appuser

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11 AS builder
+FROM eclipse-temurin:21 AS builder
 
 WORKDIR /opt/antlr4
 
@@ -14,23 +14,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install maven git -
     && mvn -DskipTests install --projects tool --also-make \
     && mv ./tool/target/antlr4-*-complete.jar antlr4-tool.jar
 
-FROM eclipse-temurin:11-jre
-
-ARG user=appuser
-ARG group=appuser
-ARG uid=1000
-ARG gid=1000
-
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "$(pwd)" \
-    --no-create-home \
-    --uid "${uid}" \
-    "${user}"
+FROM eclipse-temurin:21-jre
 
 COPY --from=builder /opt/antlr4/antlr4/antlr4-tool.jar /usr/local/lib/
 WORKDIR /work
 ENTRYPOINT ["java", "-Xmx500M", "-cp", "/usr/local/lib/antlr4-tool.jar", "org.antlr.v4.Tool"]
-
-


### PR DESCRIPTION
It seems this appuser wasn't being used at all, and the USER line wasn't being set to enable it. In addition, the adduser utility didn't exist in the old or updated version of temurin. This seems simpler and works.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
